### PR TITLE
feat:Add the contract address of the event source

### DIFF
--- a/ethetl/src/exporters/logs.rs
+++ b/ethetl/src/exporters/logs.rs
@@ -60,6 +60,7 @@ impl LogsExporter {
         let mut block_hash_vec = Vec::new();
         let mut block_number_vec = Vec::new();
         let mut contract_address_vec = Vec::new();
+        let mut event_address_vec = Vec::new();
         let mut data_vec = Vec::new();
         let mut topics_vec = Vec::new();
 
@@ -73,6 +74,7 @@ impl LogsExporter {
                 contract_address_vec.push(h160_to_hex(
                     &receipt.contract_address.unwrap_or_else(Address::zero),
                 ));
+                event_address_vec.push(h160_to_hex(&log.address));
                 data_vec.push(bytes_to_hex(&log.data));
                 let topics = log
                     .topics
@@ -91,6 +93,7 @@ impl LogsExporter {
         let block_hash_array = Utf8Array::<i32>::from_slice(block_hash_vec);
         let block_number_array = UInt64Array::from_slice(block_number_vec);
         let contract_address_array = Utf8Array::<i32>::from_slice(contract_address_vec);
+        let event_address_array = Utf8Array::<i32>::from_slice(event_address_vec);
         let data_array = Utf8Array::<i32>::from_slice(data_vec);
         let topics_array = Utf8Array::<i32>::from_slice(topics_vec);
 
@@ -108,9 +111,14 @@ impl LogsExporter {
         let block_hash_field = Field::new("block_hash", block_hash_array.data_type().clone(), true);
         let block_number_field =
             Field::new("block_number", block_number_array.data_type().clone(), true);
-        let contracet_address_field = Field::new(
+        let contract_address_field = Field::new(
             "contract_address",
             contract_address_array.data_type().clone(),
+            true,
+        );
+        let event_address_field = Field::new(
+            "event_address",
+            event_address_array.data_type().clone(),
             true,
         );
         let data_field = Field::new("data", data_array.data_type().clone(), true);
@@ -122,7 +130,8 @@ impl LogsExporter {
             transaction_index_field,
             block_hash_field,
             block_number_field,
-            contracet_address_field,
+            contract_address_field,
+            event_address_field,
             data_field,
             topics_field,
         ]);
@@ -133,6 +142,7 @@ impl LogsExporter {
             block_hash_array.boxed(),
             block_number_array.boxed(),
             contract_address_array.boxed(),
+            event_address_array.boxed(),
             data_array.boxed(),
             topics_array.boxed(),
         ])?;

--- a/schemas/databend/1_schema.sql
+++ b/schemas/databend/1_schema.sql
@@ -54,7 +54,7 @@ CREATE TABLE logs
     block_hash        VARCHAR,
     block_number      BIGINT UNSIGNED,
     contract_address  VARCHAR,
-    event_address  VARCHAR,
+    event_address     VARCHAR,
     data              VARCHAR,
     topics            VARCHAR
 );

--- a/schemas/databend/1_schema.sql
+++ b/schemas/databend/1_schema.sql
@@ -54,6 +54,7 @@ CREATE TABLE logs
     block_hash        VARCHAR,
     block_number      BIGINT UNSIGNED,
     contract_address  VARCHAR,
+    event_address  VARCHAR,
     data              VARCHAR,
     topics            VARCHAR
 );

--- a/schemas/databend/README.md
+++ b/schemas/databend/README.md
@@ -62,6 +62,7 @@ Cloud: https://app.databend.com/
 | block_hash        | VARCHAR         |
 | block_number      | BIGINT UNSIGNED |
 | contract_address  | VARCHAR         |
+| event_address     | VARCHAR         |
 | data              | VARCHAR         |
 | topics            | VARCHAR         |
 

--- a/schemas/snowflake/1_schema.sql
+++ b/schemas/snowflake/1_schema.sql
@@ -54,7 +54,7 @@ CREATE TABLE logs
     block_hash        VARCHAR,
     block_number      BIGINT,
     contract_address  VARCHAR,
-    event_address  VARCHAR,
+    event_address     VARCHAR,
     data              VARCHAR,
     topics            VARCHAR
 );

--- a/schemas/snowflake/1_schema.sql
+++ b/schemas/snowflake/1_schema.sql
@@ -54,6 +54,7 @@ CREATE TABLE logs
     block_hash        VARCHAR,
     block_number      BIGINT,
     contract_address  VARCHAR,
+    event_address  VARCHAR,
     data              VARCHAR,
     topics            VARCHAR
 );

--- a/schemas/snowflake/README.md
+++ b/schemas/snowflake/README.md
@@ -58,6 +58,7 @@ Cloud: https://app.snowflake.com/
 | block_hash        | VARCHAR           |
 | block_number      | BIGINT            |
 | contract_address  | VARCHAR           |
+| event_address     | VARCHAR         |
 | data              | VARCHAR           |
 | topics            | VARCHAR           |
 

--- a/schemas/snowflake/README.md
+++ b/schemas/snowflake/README.md
@@ -58,7 +58,7 @@ Cloud: https://app.snowflake.com/
 | block_hash        | VARCHAR           |
 | block_number      | BIGINT            |
 | contract_address  | VARCHAR           |
-| event_address     | VARCHAR         |
+| event_address     | VARCHAR           |
 | data              | VARCHAR           |
 | topics            | VARCHAR           |
 


### PR DESCRIPTION
## Summary

The contract_address field in the logs table stores the contract address if one is created in that transaction. I needed to get the contract address that was the source of the event for analysis. I'm not sure of the best naming of the fields, but didn't want the change to break anything downstream so haven't renamed contract_address.

I've also corrected a small typo in a variable name (contracet -> contract).

This is my first rust contribution, so hopefully this was the right way of doing it. Mars looks extremely useful, thanks.
